### PR TITLE
correct documentation of `F` parameter to nlsolve

### DIFF
--- a/src/nlsolve.jl
+++ b/src/nlsolve.jl
@@ -156,7 +156,7 @@ end
 A simple nonlinear solver for sparse matrices using Newton's method with
 linesearch based on Nocedal and Wright, chapter 3 section 5.
 
-This solver attempts to find x such that F = f(x), where f is a
+This solver attempts to find x such that f(x) == 0, where f is a
 nonlinear function with Jacobian J.
 
 A few points to note:
@@ -169,10 +169,11 @@ A few points to note:
 # Arguments
 - `fj!`: a function to compute a vector-valued objective function and
 its Jacobian.
-- `F`: target value for objective function.
+- `F`: matrix for holding intermediate results. Initial values may be
+  overwritten and can be bogus values.
 - `J`: sparse matrix with with the desired sparsity structure of the
-  Jacobian. Initial values are ignored and can be bogus values, as
-  long as the sparsity structure is correct.
+  Jacobian. Initial values may be overwritten and can be bogus values,
+  as long as the sparsity structure is correct.
 - `x`: initial guess for x.
 
 # Examples


### PR DESCRIPTION
As Kevin pointed out, the termination condition of nlsolve solve is f(x) = 0, not f(x) = F as I had assumed.

More broadly, the examples should perhaps be updated to clarify that the initial values in such scratch buffers are just placeholders.

(This is a place where C++ seems to do things well - often, the convention is to pass immutable arguments as `const` reference, and mutable arguments as pointers to non-`const`. This makes it clear, on the caller and callee side, as to which particular arguments to a function are (im)mutable, instead of Julia's current `!` function suffix that only indicates whether _any_ arguments are mutable, but not which ones. At least from a cursory look, it seems Julia doesn't yet have such a feature.)